### PR TITLE
Add `runtimeOnly` dependency on MOJO2 libraries with additional transformer support.

### DIFF
--- a/gradle/mixins/dependencies.gradle
+++ b/gradle/mixins/dependencies.gradle
@@ -12,6 +12,7 @@ dependencyManagement {
             entry 'mojo2-runtime-api'
             entry 'mojo2-runtime-h2o3-impl'
             entry 'mojo2-runtime-impl'
+            entry 'mojo2-runtime'
         }
         dependency group: 'com.amazonaws', name: 'aws-lambda-java-core', version: awsLambdaCoreVersion
         dependency group: 'com.amazonaws', name: 'aws-lambda-java-events', version: awsLambdaEventsVersion

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-h2o3-impl'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
+    runtimeOnly group: 'ai.h2o', name: 'mojo2-runtime', version: '2.7.11.1', ext: 'jar'
+
     constraints {
         // because https://app.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111
         compile group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4'
@@ -29,6 +31,12 @@ dependencies {
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api'
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-params'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine'
+}
+
+configurations {
+    implementation {
+        exclude group: 'org.springframework.boot', module: 'spring-boot-starter-logging'
+    }
 }
 
 test {

--- a/local-rest-scorer/build.gradle
+++ b/local-rest-scorer/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation group: 'ai.h2o', name: 'mojo2-runtime-api'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-h2o3-impl'
     implementation group: 'ai.h2o', name: 'mojo2-runtime-impl'
-    runtimeOnly group: 'ai.h2o', name: 'mojo2-runtime', version: '2.7.11.1', ext: 'jar'
+    runtimeOnly group: 'ai.h2o', name: 'mojo2-runtime', ext: 'jar'
 
     constraints {
         // because https://app.snyk.io/vuln/SNYK-JAVA-COMMONSBEANUTILS-460111


### PR DESCRIPTION
> **Note**
> This is not the ideal implementation.  Control of expected logger is lost and logs look different.  Leaving as a draft.  Will edit this description with more info later.