### PR TITLE
chore: Set up image publish workflow for feature branches

### DIFF
--- a/.github/workflows/manual-image-publish.yml
+++ b/.github/workflows/manual-image-publish.yml
@@ -1,30 +1,25 @@
-name: Publish images for PRs
+name: Publish images from Feature Branches
 
 on:
   workflow_dispatch:
-    inputs:
-      pr-number:
-        description: "PR number for docker image tag"
-        required: true
-        type: string
 
 jobs:
   setup_env:
     uses: ./.github/workflows/setup-environment.yml
 
-  build:
+  build_from_branch:
     needs: setup_env
     uses: ./.github/workflows/image-build.yml
     secrets: inherit
     with:
       component_version: ${{ needs.setup_env.outputs.component_version }}
 
-  publish_from_pr:
+  publish_from_branch:
     uses: ./.github/workflows/image-publish.yml
-    needs: build
+    needs: build_from_branch
     secrets: inherit
     with:
       gar_push_enabled: true
-      gar_image_name: us-docker.pkg.dev/vorvan/dev/mlops/pull-requests/h2oai-modelscoring-restscorer
+      gar_image_name: us-docker.pkg.dev/vorvan/dev/mlops/temp/h2oai-modelscoring-restscorer
       ecr_push_enabled: false
-      image_tags: "PR-${{ inputs.pr-number }}"
+      image_tags: "${{ needs.setup_env.outputs.sanitized_branch_name }}"

--- a/.github/workflows/pr-image-publish.yml
+++ b/.github/workflows/pr-image-publish.yml
@@ -1,0 +1,32 @@
+name: Publish images for PRs
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: "PR number for docker image tag"
+        required: true
+        type: string
+
+jobs:
+  setup_env:
+    uses: ./.github/workflows/setup-environment.yml
+
+  build:
+    needs: setup_env
+    uses: ./.github/workflows/image-build.yml
+    secrets: inherit
+    with:
+      component_version: ${{ needs.setup_env.outputs.component_version }}
+
+  publish_from_pr:
+    uses: ./.github/workflows/image-publish.yml
+    needs:
+      - setup_env
+      - build
+    secrets: inherit
+    with:
+      gar_push_enabled: true
+      gar_image_name: us-docker.pkg.dev/vorvan/dev/mlops/pull-requests/h2oai-modelscoring-restscorer
+      ecr_push_enabled: false
+      image_tags: "PR-${{ inputs.pr-number }}"

--- a/.github/workflows/pr-image-publish.yml
+++ b/.github/workflows/pr-image-publish.yml
@@ -21,9 +21,7 @@ jobs:
 
   publish_from_pr:
     uses: ./.github/workflows/image-publish.yml
-    needs:
-      - setup_env
-      - build
+    needs: build
     secrets: inherit
     with:
       gar_push_enabled: true

--- a/.github/workflows/setup-environment.yml
+++ b/.github/workflows/setup-environment.yml
@@ -15,6 +15,9 @@ on:
       component_version:
         description: "Gradle component version, such as 1.2.3"
         value: ${{ jobs.setup_env.outputs.component_version }}
+      sanitized_branch_name:
+        description: "Branch name where / is replaced by -"
+        value: ${{ jobs.setup_env.outputs.sanitized_branch_name }}
 
 jobs:
   setup_env:
@@ -25,6 +28,7 @@ jobs:
       release_base_version: ${{ steps.release_base_version.outputs.version }}
       release_version: ${{ steps.release_version.outputs.version }}
       component_version: ${{ steps.component_version.outputs.version }}
+      sanitized_branch_name: ${{ steps.sanitized_branch_name.outputs.name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,3 +66,9 @@ jobs:
             version=0.0.0-pr.${{ steps.commit_hash.outputs.sha }}
           fi
           echo "version=$version" >> $GITHUB_OUTPUT
+
+      - name: Save Sanitized Branch Name
+        id: sanitized_branch_name
+        run: |
+          name=$(echo ${{ github.head_ref }} | sed -r 's/\//-/g')
+          echo "name=$name" >> $GITHUB_OUTPUT


### PR DESCRIPTION
**Description**
This workflow is designed to enable manual publishing of image artifacts from any branches. The images will be pushed to a dedicated repository (`temp/`) and automatically cleaned up on a weekly basis. 

The image registry location :: `us-docker.pkg.dev/vorvan/dev/mlops/temp/<<COMPONENT_NAME>>`

The image tag will be the branch name :: for branch `rupee/push-image` -> tag would be `rupee-push-image`