### PR TITLE
feat: Migrate image registry from GAR to AWS ECR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,10 @@ jobs:
       - build_image
     secrets: inherit
     with:
-      gar_push_enabled: true
-      ecr_push_enabled: false
-      gar_image_name: us-docker.pkg.dev/vorvan/dev/h2oai-modelscoring-restscorer
-      image_tags: "${{ needs.setup_env.outputs.commit_hash }},latest"
+      ecr_mlops_push_enabled: true
+      ecr_h2o_push_enabled: false
+      ecr_mc_push_enabled: false
+      image_tags: "sha-${{ needs.setup_env.outputs.commit_hash }},latest"
 
   publish_latest_from_release_branch:
     if: startsWith(github.ref, 'refs/heads/release/')
@@ -94,10 +94,10 @@ jobs:
       - build_image
     secrets: inherit
     with:
-      gar_push_enabled: true
-      ecr_push_enabled: false
-      gar_image_name: us-docker.pkg.dev/vorvan/dev/h2oai-modelscoring-restscorer
-      image_tags: "${{ needs.setup_env.outputs.commit_hash }},latest-${{ needs.setup_env.outputs.release_base_version }}"
+      ecr_mlops_push_enabled: true
+      ecr_h2o_push_enabled: false
+      ecr_mc_push_enabled: false
+      image_tags: "sha-${{ needs.setup_env.outputs.commit_hash }},latest-${{ needs.setup_env.outputs.release_base_version }}"
 
   publish_release:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -107,10 +107,9 @@ jobs:
       - build_image
     secrets: inherit
     with:
-      gar_push_enabled: true
-      ecr_push_enabled: true
-      gar_image_name: us-docker.pkg.dev/vorvan/dev/h2oai-modelscoring-restscorer
-      ecr_image_name: 926522735405.dkr.ecr.us-east-1.amazonaws.com/h2oai-modelscoring-restscorer
+      ecr_mlops_push_enabled: true
+      ecr_h2o_push_enabled: true
+      ecr_mc_push_enabled: true
       image_tags: "v${{ needs.setup_env.outputs.release_version }}"
 
   release:

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -2,25 +2,32 @@ name: Publish Images
 
 on:
   workflow_call:
-    secrets:
-      GCR_JSON_KEY:
-        required: true
-
     inputs:
-      gar_push_enabled:
-        description: "Enable image push to GAR"
+      ecr_mlops_push_enabled:
+        description: "Enable image push to MLOps ECR"
         required: true
         type: boolean
-      ecr_push_enabled:
-        description: "Enable image push to ECR"
+      ecr_h2o_push_enabled:
+        description: "Enable image push to H2O ECR"
         required: true
         type: boolean
-      gar_image_name:
-        description: "Docker Registry and Repository for GAR"
+      ecr_mc_push_enabled:
+        description: "Enable image push to MC ECR"
+        required: true
+        type: boolean
+      ecr_mlops_image_name:
+        description: "Docker Registry and Repository for MLOps ECR"
+        default: "004258836109.dkr.ecr.us-east-1.amazonaws.com/h2oai-modelscoring-restscorer"
         required: false
         type: string
-      ecr_image_name:
+      ecr_h2o_image_name:
+        description: "Docker Registry and Repository for H2O ECR"
+        default: "353750902984.dkr.ecr.us-east-1.amazonaws.com/h2oai-modelscoring-restscorer"
+        required: false
+        type: string
+      ecr_mc_image_name:
         description: "Docker Registry and Repository for MC ECR"
+        default: "926522735405.dkr.ecr.us-east-1.amazonaws.com/h2oai-modelscoring-restscorer"
         required: false
         type: string
       image_tags:
@@ -46,8 +53,9 @@ jobs:
           full_tags=()
           # Split the comma-separated tags and iterate over each tag
           for tag in $(echo "${{ inputs.image_tags }}" | tr ',' ' '); do
-            if [[ "${{ inputs.gar_push_enabled }}" == "true" ]]; then full_tags+=("${{ inputs.gar_image_name }}:${tag}"); fi
-            if [[ "${{ inputs.ecr_push_enabled }}" == "true" ]]; then full_tags+=("${{ inputs.ecr_image_name }}:${tag}"); fi
+            if [[ "${{ inputs.ecr_mlops_push_enabled }}" == "true" ]]; then full_tags+=("${{ inputs.ecr_mlops_image_name }}:${tag}"); fi
+            if [[ "${{ inputs.ecr_h2o_push_enabled }}" == "true" ]]; then full_tags+=("${{ inputs.ecr_h2o_image_name }}:${tag}"); fi
+            if [[ "${{ inputs.ecr_mc_push_enabled }}" == "true" ]]; then full_tags+=("${{ inputs.ecr_mc_image_name }}:${tag}"); fi
           done
 
           # Join the full tags array into a single string separated by commas
@@ -58,24 +66,40 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GAR
-        if: ${{ inputs.gar_push_enabled }}
-        uses: docker/login-action@v3
-        with:
-          registry: us-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GCR_JSON_KEY }}
-
-      - name: Configure MC AWS credentials
-        if: ${{ inputs.ecr_push_enabled }}
+      - name: Configure MLOps AWS credentials
+        if: ${{ inputs.ecr_mlops_push_enabled }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::926522735405:role/h2o-github-oidc-ecr-role
-          role-session-name: h2oai-external-adapter-MC-ECR
+          role-to-assume: arn:aws:iam::004258836109:role/GitHub-OIDC-Role
+          role-session-name: mlops-dai-runtimes
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
-        if: ${{ inputs.ecr_push_enabled }}
+        if: ${{ inputs.ecr_mlops_push_enabled }}
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Configure H2O AWS credentials
+        if: ${{ inputs.ecr_h2o_push_enabled }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::353750902984:role/GitHub-OIDC-Role
+          role-session-name: mlops-dai-runtimes
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        if: ${{ inputs.ecr_h2o_push_enabled }}
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Configure MC AWS credentials
+        if: ${{ inputs.ecr_mc_push_enabled }}
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::926522735405:role/h2o-github-oidc-ecr-role
+          role-session-name: mlops-dai-runtimes-MC-ECR
+          aws-region: us-east-1
+
+      - name: Login to Amazon ECR
+        if: ${{ inputs.ecr_mc_push_enabled }}
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Download artifact

--- a/.github/workflows/image-publish.yml
+++ b/.github/workflows/image-publish.yml
@@ -109,8 +109,7 @@ jobs:
           path: /tmp
 
       - name: Docker Load
-        run: |
-          docker load -i /tmp/image.tar
+        run: docker load -i /tmp/image.tar
 
       - name: Tag and push Docker image
         run: |

--- a/.github/workflows/manual-image-publish.yml
+++ b/.github/workflows/manual-image-publish.yml
@@ -21,7 +21,7 @@ jobs:
       - build_from_branch
     secrets: inherit
     with:
-      gar_push_enabled: true
-      gar_image_name: us-docker.pkg.dev/vorvan/mlops-dev/h2oai-modelscoring-restscorer
-      ecr_push_enabled: false
-      image_tags: "${{ needs.setup_env.outputs.sanitized_branch_name }}-${{ needs.setup_env.outputs.commit_hash }}"
+      ecr_mlops_push_enabled: true
+      ecr_h2o_push_enabled: false
+      ecr_mc_push_enabled: false
+      image_tags: "branch-${{ needs.setup_env.outputs.sanitized_branch_name }}-${{ needs.setup_env.outputs.commit_hash }}"


### PR DESCRIPTION
**Description**

This PR addresses the image registry migration from GAR to AWS ECR.
- Final release images will be published to MLOps ECR, H2O ECR, and MC ECR.
- Snapshots and latest images will be published to MLOps ECR.

We also updated the tag format for events like merges to the main/release branch and manual pushes:
- For commits: `sha-{commit}`
- For manual pushes: `branch-{branch_name}`

------------------

We applied ECR lifecycle policies for the repo:
- Rule 1: Remove images older than 7 days with the `branch-*` wildcard tag _(for manually published images)_.
- Rule 2: Remove images older than 30 days with the `sha-*` wildcard tag _(for snapshots/latest)_.
